### PR TITLE
chore(git): normalize EOL via .gitattributes (LF for code; CRLF for Windows scripts)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,11 @@ tools/coveragerc.digest text eol=lf
 *.yml    text eol=lf
 *.yaml   text eol=lf
 *.md     text eol=lf
+
+*.py text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.sh text eol=lf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+


### PR DESCRIPTION
## Summary
- Ввів єдині правила переведення рядка через .gitattributes.
- Код/конфіги → LF; Windows-скрипти (.ps1/.cmd/.bat) → CRLF.

## Why
- Послідовні лайн-ендинги = менше «noise» у дифах і стабільніші хуки.

## Changes
- .gitattributes: * text=auto; LF для *.py, *.md, *.yml/.yaml, *.toml, *.sh; CRLF для *.ps1, *.cmd, *.bat.
- `git add --renormalize .` (без фактичних змін файлів).

## Verify
- `pre-commit run --hook-stage manual -a` — має пройти без змін.
- Перевірити, що нові коміти не створюють «line endings» дифів.
