### PR TITLE
docs(IRM): regenerate IRM.md from SSOT (docs/irm.phase6.yaml) for Phase 6 + guard checks

### DIFF
--- a/docs/IRM.md
+++ b/docs/IRM.md
@@ -120,6 +120,16 @@ _Статуси_: **todo** — ще не почато, **doing** — в робо
   - [ ] Repo hygiene: прибрано зайві файли/логи/бекапи; додано правила до .gitignore; перенесено dev/ → docs/dev/; додано ігнор для root IRM.md.
   - [ ] pre-commit manual stage: усі хуки проходять без змін.
 
+- [x] **6.2.6 — QS/mypy: alerts & telegram label; generator hygiene**  `status: done`
+  - [ ] fix(telegram): LABEL prefix: LABEL  у сповіщеннях; експорт send_telegram() для прямого виклику; сумісність з тестом tests/test_notify_telegram_label.py.
+  - [ ] fix(alerts): уніфіковано API AlertGate/SqliteAlertGateRepo: commit(), should_send(), normalized reasons (cooldown, suppressed-by-eps, Δbasis_…).
+  - [ ] chore(dev): додано types-requests для mypy; приведено дотичні модулі до mypy clean.
+  - [ ] refactor: легкий mypy/ruff clean у змінених файлах (без зміни бізнес-логіки).
+  - [ ] mypy clean: src/core/alerts_gate.py, src/infra/alerts_repo.py, src/infra/notify_telegram.py, src/core/alerts_hook.py.
+  - [ ] pytest -q: тестові набори alerts/tg/ws — 10/10 passed; повний прогін: 144 passed, 1 skipped.
+  - [ ] pre-commit OK (ruff, ruff-format, isort, whitespace hooks).
+  - [ ] WA: виконано на тимчасовій гілці; один-крок-за-раз; мінімальний ризик — лише формат повідомлень TG.
+
 <!-- IRM:END 6.2 -->
 
 ### Фаза 6.3 — Історія (SQLite) та фільтри ліквідності

--- a/docs/irm.phase6.yaml
+++ b/docs/irm.phase6.yaml
@@ -64,3 +64,15 @@ sections:
       - 'Repo hygiene: прибрано зайві файли/логи/бекапи; додано правила до .gitignore;
         перенесено dev/ → docs/dev/; додано ігнор для root IRM.md.'
       - 'pre-commit manual stage: усі хуки проходять без змін.'
+  - id: "6.2.6"
+    name: "QS/mypy: alerts & telegram label; generator hygiene"
+    status: "done"
+    tasks:
+      - "fix(telegram): LABEL prefix: LABEL  у сповіщеннях; експорт send_telegram() для прямого виклику; сумісність з тестом tests/test_notify_telegram_label.py."
+      - "fix(alerts): уніфіковано API AlertGate/SqliteAlertGateRepo: commit(), should_send(), normalized reasons (cooldown, suppressed-by-eps, Δbasis_…)."
+      - "chore(dev): додано types-requests для mypy; приведено дотичні модулі до mypy clean."
+      - "refactor: легкий mypy/ruff clean у змінених файлах (без зміни бізнес-логіки)."
+      - "mypy clean: src/core/alerts_gate.py, src/infra/alerts_repo.py, src/infra/notify_telegram.py, src/core/alerts_hook.py."
+      - "pytest -q: тестові набори alerts/tg/ws — 10/10 passed; повний прогін: 144 passed, 1 skipped."
+      - "pre-commit OK (ruff, ruff-format, isort, whitespace hooks)."
+      - "WA: виконано на тимчасовій гілці; один-крок-за-раз; мінімальний ризик — лише формат повідомлень TG."


### PR DESCRIPTION
Що змінено

1-- Оновлено джерело правди (SSOT): docs/irm.phase6.yaml.
Згенеровано актуальний план docs/IRM.md через генератор tools/irm_phase6_gen.py.
Пройдено перевірки узгодженості та якості (WA/QUALITY).

2--Навіщо
Щоб синхронізувати Implementation Roadmap з останніми змінами Phase 6 і підтримувати єдине джерело правди (SSOT → IRM.md), згідно з WA.md та QUALITY.md.

3--  Як перевірити локально
# Перевірка консистентності SSOT
   + python .\tools\irm_phase6_gen.py --check

# Побудова IRM.md з SSOT
  +   python .\tools\irm_phase6_gen.py --write
 
# Тести генератора та guard
  +    pytest -q tests/test_irm_phase6_gen.py tests/test_irm_phase6_guard.py

# Легкі гейтки якості
   +   pre-commit run --files docs/irm.phase6.yaml docs/IRM.md tools/irm_phase6_gen.py
   +   mypy tools/irm_phase6_gen.py

4-- Обсяг змін (скоуп)
-  docs/irm.phase6.yaml — ручні правки SSOT.
-  docs/IRM.md — автогенерація з SSOT.

Коду рантайму не торкаємось (ризик мінімальний).

5--Критерії приймання (Acceptance)
-   python tools/irm_phase6_gen.py --check проходить без помилок.
-   python tools/irm_phase6_gen.py --write детерміністично відтворює docs/IRM.md.
-   pytest для tests/test_irm_phase6_* — зелений.

Вміст docs/IRM.md відповідає оновленим крокам/віхам Phase 6.
Відповідність вимогам з WA.md і QUALITY.md.
Ризики / зворотність
Низькі: лише документація. У разі потреби можна швидко відкотити docs/IRM.md та/або docs/irm.phase6.yaml.