### PR TITLE
Feat/step 6.3.6 sqlite maintenance

### DIFF
--- a/scripts/e2e_bybit.py
+++ b/scripts/e2e_bybit.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+scripts/e2e_bybit.py
+
+Wrapper runner with a correct environment banner (demo/testnet/main/custom).
+It prints the detected environment and then delegates to the existing
+`scripts.e2e_bybit_testnet` module, preserving its functionality
+(create/cancel order via BYBIT_* env vars, etc.).
+"""
+
+import os
+import sys
+import subprocess
+
+
+def detect_env_label() -> str:
+    url = os.getenv("BYBIT_PRIVATE_URL") or os.getenv("BYBIT_PUBLIC_URL") or ""
+    url_l = url.lower()
+
+    if "api-demo.bybit.com" in url_l:
+        return "demo"
+    if "api-testnet.bybit.com" in url_l:
+        return "testnet"
+    if "api.bybit.com" in url_l:
+        return "main"
+    if url:
+        return f"custom({url})"
+    return "unknown"
+
+
+def main() -> int:
+    label = detect_env_label()
+    pub = os.getenv("BYBIT_PUBLIC_URL", "<unset>")
+    prv = os.getenv("BYBIT_PRIVATE_URL", "<unset>")
+
+    print(f"== E2E ({label}) : env check ==")
+    print(f"PUBLIC_URL  : {pub}")
+    print(f"PRIVATE_URL : {prv}")
+
+    # If WS endpoints are explicitly set, show them too (useful for demo)
+    ws_spot = os.getenv("WS_PUBLIC_URL_SPOT")
+    ws_lin  = os.getenv("WS_PUBLIC_URL_LINEAR")
+    if ws_spot or ws_lin:
+        print("WS endpoints:")
+        if ws_spot:
+            print(f"  WS_PUBLIC_URL_SPOT  : {ws_spot}")
+        if ws_lin:
+            print(f"  WS_PUBLIC_URL_LINEAR: {ws_lin}")
+
+    print("\n-- Delegating to legacy runner: scripts.e2e_bybit_testnet --\n")
+    # Delegate to existing test script so behavior stays identical
+    try:
+        result = subprocess.run([sys.executable, "-m", "scripts.e2e_bybit_testnet"], check=False)
+        return result.returncode
+    except FileNotFoundError as e:
+        print("ERROR: Could not locate the legacy module 'scripts.e2e_bybit_testnet'.")
+        print("Make sure it exists in your repository. Original error:", e)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load.bybit.env.ps1
+++ b/scripts/load.bybit.env.ps1
@@ -1,45 +1,94 @@
-<#
-  Завантажує змінні BYBIT_* з .env-файлу (дефолт: config\bybit.secrets.env)
-  Сумісно з Windows PowerShell 5.1 (без тернарного оператора).
-  Використання:
-    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
-    .\scripts\load.bybit.env.ps1
-    # або:
-    .\scripts\load.bybit.env.ps1 -Path "C:\path\to\file.env"
-#>
+﻿[CmdletBinding()]
 param(
-  [string]$Path = "config\bybit.secrets.env"
+  # Можна передати інший шлях до .env за потреби
+  [string]$EnvFile
 )
 
-if (-not (Test-Path -LiteralPath $Path)) {
-  Write-Error "Файл '$Path' не знайдено. Створи його за шаблоном у config\bybit.secrets.env"
-  exit 1
+$ErrorActionPreference = 'Stop'
+
+# ---- helpers ----
+function Mask {
+  param([string]$v, [int]$Head=4, [int]$Tail=2)
+  if ([string]::IsNullOrEmpty($v)) { return '<empty>' }
+  if ($v.Length -le ($Head + $Tail)) { return ('*' * $v.Length) }
+  return $v.Substring(0,$Head) + ('*' * ($v.Length - ($Head + $Tail))) + $v.Substring($v.Length-$Tail)
 }
-
-$lines = Get-Content -LiteralPath $Path -Encoding UTF8
-
-foreach ($line in $lines) {
-  $t = $line.Trim()
-  if ([string]::IsNullOrWhiteSpace($t)) { continue }
-  if ($t.StartsWith("#")) { continue }
-  if ($t -notmatch "=") { continue }
-
-  $kv = $t.Split("=", 2)
-  $key = $kv[0].Trim()
-  $val = $kv[1].Trim()
-
-  if ($val.StartsWith('"') -and $val.EndsWith('"')) { $val = $val.Substring(1, $val.Length - 2) }
-  if ($val.StartsWith("'") -and $val.EndsWith("'")) { $val = $val.Substring(1, $val.Length - 2) }
-
-  [System.Environment]::SetEnvironmentVariable($key, $val, "Process")
-
-  if ($key -match "SECRET|KEY") {
-    Write-Host ("Set {0}=****" -f $key)
+function ToDisplay {
+  param([string]$s)
+  if ([string]::IsNullOrEmpty($s)) { return '<empty>' } else { return $s }
+}
+function Show {
+  param([string]$label, [string]$value)
+  if ([string]::IsNullOrEmpty($value)) {
+    Write-Host ("{0,-26}: <empty>" -f $label)
   } else {
-    Write-Host ("Set {0}={1}" -f $key, $val)
+    Write-Host ("{0,-26}: {1}" -f $label, $value)
   }
 }
 
-Write-Host ""
-Write-Host "Перевірка:  gci env:BYBIT_* | ft Name,Value -AutoSize"
-Write-Host "Smoke (баланс, без торгів):  python -m scripts.e2e_bybit_testnet"
+# ---- resolve default EnvFile from script location ----
+if (-not $EnvFile -or $EnvFile.Trim() -eq '') {
+  # $PSCommandPath працює в PS 5.1 при запуску файлу (не в REPL)
+  $scriptDir = Split-Path -Path $PSCommandPath -Parent
+  $repoRoot  = Split-Path -Path $scriptDir -Parent
+  $EnvFile   = Join-Path $repoRoot '.env'
+}
+
+# ---- read .env ----
+if (-not (Test-Path -LiteralPath $EnvFile)) {
+  throw ".env not found at: $EnvFile"
+}
+$envText = Get-Content -Raw -Encoding UTF8 -LiteralPath $EnvFile
+
+# ---- parse .env -> hashtable ----
+$kv = @{}
+foreach ($line in ($envText -split "`n")) {
+  $l = $line.Trim()
+  if (-not $l) { continue }
+  if ($l.StartsWith('#')) { continue }
+  if ($l -notmatch '^\s*([A-Za-z_][A-Za-z0-9_+]*)\s*=\s*(.*)\s*$') { continue }
+  $k = $matches[1]
+  $v = $matches[2]
+  if ($v.Length -ge 2) {
+    if (($v.StartsWith('"') -and $v.EndsWith('"')) -or ($v.StartsWith("'") -and $v.EndsWith("'"))) {
+      $v = $v.Substring(1, $v.Length - 2)
+    }
+  }
+  $kv[$k] = $v
+}
+
+# ---- keys to lift into Process scope ----
+$keys = @(
+  'BYBIT_PUBLIC_URL','BYBIT_PRIVATE_URL','BYBIT_DEFAULT_CATEGORY',
+  'BYBIT_API_KEY','BYBIT_API_SECRET',
+  'BYBIT_USE_SERVER_TIME','BYBIT_RECV_WINDOW_MS',
+  'TELEGRAM__BOT_TOKEN','TELEGRAM__ALERT_CHAT_ID'
+)
+
+# clear process-scope remnants first
+foreach ($k in $keys) { Remove-Item -Path "Env:$k" -ErrorAction SilentlyContinue }
+
+# set values from .env (if present)
+foreach ($k in $keys) {
+  if ($kv.ContainsKey($k)) {
+    [Environment]::SetEnvironmentVariable($k, $kv[$k], 'Process')
+  }
+}
+
+# testnet defaults if requested
+if ($kv.ContainsKey('BYBIT_IS_TESTNET') -and $kv['BYBIT_IS_TESTNET'] -eq '1') {
+  if (-not $env:BYBIT_PUBLIC_URL)  { [Environment]::SetEnvironmentVariable('BYBIT_PUBLIC_URL','https://api-testnet.bybit.com','Process') }
+  if (-not $env:BYBIT_PRIVATE_URL) { [Environment]::SetEnvironmentVariable('BYBIT_PRIVATE_URL','https://api-testnet.bybit.com','Process') }
+}
+
+# ---- diag ----
+Write-Host "Loaded .env from: $EnvFile"
+Show "BYBIT_PUBLIC_URL"          $env:BYBIT_PUBLIC_URL
+Show "BYBIT_PRIVATE_URL"         $env:BYBIT_PRIVATE_URL
+Write-Host ("{0,-26}: {1}" -f "BYBIT_DEFAULT_CATEGORY", (ToDisplay $env:BYBIT_DEFAULT_CATEGORY))
+Write-Host ("{0,-26}: {1}" -f "BYBIT_API_KEY",          (Mask $env:BYBIT_API_KEY))
+Write-Host ("{0,-26}: {1}" -f "BYBIT_API_SECRET",       (Mask $env:BYBIT_API_SECRET))
+Write-Host ("{0,-26}: {1}" -f "BYBIT_USE_SERVER_TIME",  (ToDisplay $env:BYBIT_USE_SERVER_TIME))
+Write-Host ("{0,-26}: {1}" -f "BYBIT_RECV_WINDOW_MS",   (ToDisplay $env:BYBIT_RECV_WINDOW_MS))
+Write-Host ("{0,-26}: {1}" -f "TELEGRAM__BOT_TOKEN",    (Mask $env:TELEGRAM__BOT_TOKEN))
+Write-Host ("{0,-26}: {1}" -f "TELEGRAM__ALERT_CHAT_ID",(ToDisplay $env:TELEGRAM__ALERT_CHAT_ID))

--- a/scripts/smoke_bybit_ws.py
+++ b/scripts/smoke_bybit_ws.py
@@ -1,49 +1,70 @@
 import asyncio
 import os
 from contextlib import suppress
+from typing import Optional
 
 from exchanges.bybit.ws_public import BybitWsPublic, Ticker
-
 
 def _print_ticker(t: Ticker) -> None:
     print(f"WS Ticker: {t}")
 
+def _detect_host_label(base_http: str) -> str:
+    b = (base_http or "").lower()
+    if "api-testnet.bybit.com" in b:
+        return "testnet"
+    if "api-demo.bybit.com" in b or "demo" in b:
+        return "demo"
+    return "mainnet"
+
+def _ws_url_for(category: str, host_label: str) -> str:
+    # Allow explicit overrides
+    if category == "spot":
+        override = os.getenv("WS_PUBLIC_URL_SPOT") or os.getenv("WS_PUBLIC_URL")
+        if override:
+            return override
+    else:
+        override = os.getenv("WS_PUBLIC_URL_LINEAR") or os.getenv("WS_PUBLIC_URL")
+        if override:
+            return override
+
+    # Fallbacks based on host label
+    if host_label == "testnet":
+        return f"wss://stream-testnet.bybit.com/v5/public/{category}"
+    if host_label == "demo":
+        return f"wss://stream-demo.bybit.com/v5/public/{category}"
+    # mainnet default
+    return f"wss://stream.bybit.com/v5/public/{category}"
 
 async def main() -> None:
     symbol = os.getenv("BYBIT_SYMBOL", "BTCUSDT")
     category = os.getenv("BYBIT_DEFAULT_CATEGORY", "spot") or "spot"
+    seconds = int(os.getenv("WS_SMOKE_DURATION_SEC", os.getenv("BYBIT_WS_SMOKE_DURATION_SEC", "12")))
 
-    ws = BybitWsPublic(symbol, on_ticker=_print_ticker, category=category)
+    base_http = os.getenv("BYBIT_PUBLIC_URL") or os.getenv("BYBIT_PRIVATE_URL") or ""
+    host_label = _detect_host_label(base_http)
+    ws_url = _ws_url_for(category, host_label)
 
-    seconds = int(os.getenv("BYBIT_WS_SMOKE_SECONDS", "12"))
-    # Діагностичний заголовок (не містить секретів)
-    print(
-        f"[WS smoke] category={ws.category} symbol={symbol} "
-        f"host={'testnet' if 'testnet' in (os.getenv('BYBIT_PUBLIC_URL', '')) else 'mainnet'} "
-        f"url={getattr(ws, '_url', '?')} "
-        f"duration={seconds}s"
-    )
+    # Header
+    print(f"[WS smoke] category={category} symbol={symbol} host={host_label} url={ws_url} duration={seconds}s")
 
     recv_count = 0
-
-    # Обгорнемо користувацький колбек, щоб порахувати тікери
-    def _counting_cb(t: Ticker) -> None:
+    def on_ticker(t: Ticker) -> None:
         nonlocal recv_count
         recv_count += 1
         _print_ticker(t)
 
-    ws.on_ticker = _counting_cb
+    ws = BybitWsPublic(symbol, on_ticker=on_ticker, category=category)
 
     task = asyncio.create_task(ws.run())
-    await asyncio.sleep(seconds)
-
-    # Плавна зупинка + чек завершення
-    await ws.stop()
-    with suppress(asyncio.CancelledError):
-        await task
+    try:
+        await asyncio.sleep(seconds)
+    finally:
+        # Плавна зупинка + чек завершення
+        await ws.stop()
+        with suppress(asyncio.CancelledError):
+            await task
 
     print(f"[WS smoke] received={recv_count} tickers, done.")
-
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
### Summary
Wire-up DEMO (api-demo.bybit.com) для REST/WS + діагностика і E2E-smoke.

### Changes
- scripts/load.bybit.env.ps1 — підтримка DEMO (api-demo), коректне маскування ключів.
- scripts/safe.show.bybit.env.ps1 — безпечний вивід + перевірки.
- scripts/smoke_bybit_ws.py — підтримка DEMO WS через `WS_PUBLIC_URL_SPOT/LINEAR`, коректний `host=demo` у логах.
- scripts/e2e_bybit.py — банер середовища + делегація до легасі раннера.

### How to test (done)
```powershell
# DEMO env
$env:BYBIT_PUBLIC_URL='https://api-demo.bybit.com'
$env:BYBIT_PRIVATE_URL='https://api-demo.bybit.com'
$env:WS_PUBLIC_URL_SPOT='wss://stream-demo.bybit.com/v5/public/spot'
$env:WS_PUBLIC_URL_LINEAR='wss://stream-demo.bybit.com/v5/public/linear'

# діагностика ключів
python -m scripts.diag_bybit_keys    # retCode: 0, баланси-перегляд

# REST тикер + баланси
python -m scripts.smoke_bybit

# WS тикер (має бути host=demo)
python -m scripts.smoke_bybit_ws

# E2E (без ордерів)
python -m scripts.e2e_bybit

# E2E (з ордером, далі прибрати прапор)
$env:BYBIT_ORDER_SIDE='buy'; $env:BYBIT_ORDER_QTY='0.001'; $env:BYBIT_ORDER_PRICE='100000'; $env:BYBIT_PLACE_ORDER='1'
python -m scripts.e2e_bybit_testnet
Remove-Item Env:BYBIT_PLACE_ORDER -ErrorAction SilentlyContinue
