### PR TITLE
docs: підтримка DEMO (api-demo), WS demo endpoints та приклади E2E (v6.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@
 > що відповідають нашому внутрішньому Implementation Roadmap (IRM).
 
 `------------------------------------------------------------------------------------------------------------------------------`
+## [6.3.6] — 2025-09-07
+**Phase 6 — Step-6.3.6 · DEMO env (api-demo) + WS host=demo + env loader hardening**
+
+### Added
+- **DEMO середовище (`api-demo.bybit.com`)** під ключами з `.env` і змінними оточення.
+  - `scripts/load.bybit.env.ps1` — коректно підтягує DEMO URL-и для **REST** і маскує ключі.
+  - `scripts/safe.show.bybit.env.ps1` — безпечно показує замасковані ключі та **api-demo** в host.
+  - **WS-ендпоїнти можна перевизначити** через `WS_PUBLIC_URL_SPOT` і `WS_PUBLIC_URL_LINEAR`.
+  - `scripts/smoke_bybit_ws.py` — читає ці змінні та логікує **host=demo** в заголовку.
+  - `scripts/e2e_bybit.py` — банер середовища (REST/WS) і делегація до легасі-раннера для e2e.
+
+### Changed
+- `scripts/e2e_bybit_testnet.py` — узгоджено повідомлення для DEMO‑рунів; шлях створення/скасування ордера
+  лишився попереднім і активується прапором `BYBIT_PLACE_ORDER=1`.
+
+### Notes
+- Тестовий прогін: REST підпис/баланси (`retCode: 0`), WS тікери з **host=demo**, e2e створення/скасування ордера — ок.
+- Релізний тег: **v6.3.6**.
+
+[6.3.6]: https://github.com/VadymTeterin/bybit-arb-bot/compare/v6.3.5...v6.3.6
+
+`------------------------------------------------------------------------------------------------------------------------------`
 ## [6.3.5] — 2025-08-27
 **Phase 6 — Step-6.3.4 / 6.3.5 · Alerts cooldown + suppression + persistence**
 


### PR DESCRIPTION
# docs: підтримка DEMO (api-demo), WS demo endpoints та приклади E2E (v6.3.6)

## Що змінено
- **README.md**:
  - Додано інструкції для **DEMO** середовища: `https://api-demo.bybit.com`, окремі DEMO-ключі.
  - Окремий блок для **WS DEMO** ендпоїнтів:  
    `WS_PUBLIC_URL_SPOT = wss://stream-demo.bybit.com/v5/public/spot`  
    `WS_PUBLIC_URL_LINEAR = wss://stream-demo.bybit.com/v5/public/linear`
  - Додано приклади валідації: `scripts.diag_bybit_keys`, `scripts.smoke_bybit`, `scripts.smoke_bybit_ws`, `scripts.e2e_bybit`.
  - Нагадування про безпеку: виконання ордерів тільки з `BYBIT_PLACE_ORDER=1`.
- **CHANGELOG.md**:
  - Опис релізу **v6.3.6**: DEMO env, WS host=demo у логах, e2e-приклади.

> **Примітка:** це **docs-only PR** — змін у коді немає.

---

## Навіщо
- У Bybit є окремі ключі для **testnet** та **demo** (на main-інфрі), що часто плутають.
- Документація тепер чітко розводить **api-testnet** vs **api-demo** та показує валідні WS ендпоїнти для DEMO.
- Додані покрокові перевірки (REST/WS/E2E), щоби швидко валіднути інтеграцію без ризику випадкових ордерів.

---

## Як перевірити
1. **ENV для DEMO** (PowerShell):
   ```powershell
   $env:BYBIT_PUBLIC_URL  = 'https://api-demo.bybit.com'
   $env:BYBIT_PRIVATE_URL = 'https://api-demo.bybit.com'

   # явні WS DEMO endpoints (опційно)
   $env:WS_PUBLIC_URL_SPOT   = 'wss://stream-demo.bybit.com/v5/public/spot'
   $env:WS_PUBLIC_URL_LINEAR = 'wss://stream-demo.bybit.com/v5/public/linear'

   # DEMO API keys
   $env:BYBIT_API_KEY    = '<DEMO_KEY>'
   $env:BYBIT_API_SECRET = '<DEMO_SECRET>'
   $env:BYBIT_USE_SERVER_TIME = '1'
   $env:BYBIT_RECV_WINDOW_MS  = '20000'
   ```

2. **REST-перевірка підпису/балансів**:
   ```powershell
   python -m scripts.diag_bybit_keys
   # очікуємо retCode: 0 двічі
   ```

3. **WS-перевірка** (має показувати `host=demo`):
   ```powershell
   python -m scripts.smoke_bybit_ws
   ```

4. **E2E-перевірка без ордерів**:
   ```powershell
   python -m scripts.e2e_bybit
   ```

5. *(Опц.)* **create/cancel** ордер на DEMO і відразу вимкнути:
   ```powershell
   $env:BYBIT_ORDER_SIDE='buy'; $env:BYBIT_ORDER_QTY='0.001'; $env:BYBIT_ORDER_PRICE='100000'; $env:BYBIT_PLACE_ORDER='1'
   python -m scripts.e2e_bybit_testnet
   Remove-Item Env:BYBIT_PLACE_ORDER -ErrorAction SilentlyContinue
   ```

---

## Ризики / зворотна сумісність
- Відсутні. Лише оновлення документації. Поточні робочі сценарії не зачіпаються.

---

## Додатково
- Чекпоінти: `checkpoint-demo-keys`, `checkpoint-demo-e2e-ok`.
- Релізний тег: **v6.3.6** (цей PR синхронізує доки з фактичним станом).

---

## Чекліст
- [x] Оновлено **README.md** та **CHANGELOG.md** без зміни порядку розділів/оформлення
- [x] Всі приклади команд перевірені на DEMO
- [x] Немає лейків секретів (усе замасковано)
- [x] Backward-compatible
