### PR TITLE
docs(changelog): add Unreleased ops note for hardened Windows scheduler runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 > що відповідають нашому внутрішньому Implementation Roadmap (IRM).
 
 `------------------------------------------------------------------------------------------------`
+
+## [Unreleased]
+### Ops
+- Windows Task Scheduler: hardened runner — sets working directory to repo root, resolves absolute DB path, forces UTF-8 I/O, uses direct `.py` call; fixed `schtasks` flags and full path to `powershell.exe`.
+
+
+`------------------------------------------------------------------------------------------------`
 ## [6.3.7] — 2025-09-14
 **Phase 6 — Step-6.3.7 · Documentation update (README/CHANGELOG/HISTORY_AND_FILTERS)**
 


### PR DESCRIPTION
**What**
Add an “Unreleased” entry to CHANGELOG documenting the recent ops hardening of the Windows Task Scheduler runner.

**Details**
- Runner now:
  - sets working directory to the repo root,
  - resolves an absolute DB path,
  - forces UTF-8 I/O,
  - invokes CLI via direct `.py` (no `-m`),
- Scheduler registration fixed:
  - correct `schtasks` flags for `/SC DAILY`,
  - full path to `powershell.exe` in `/TR`.

**Why**
To avoid intermittent scheduler failures (`LastTaskResult=1`) due to missing working dir, code page issues, and `-m` module resolution under the scheduler context.

**Scope**
Docs-only change (CHANGELOG). No code behavior changes.

**Validation**
- Manual: scheduled task runs successfully (`LastTaskResult = 0`), log ends with `SQLiteMaint DONE`.
