### PR TITLE
docs(IRM): mark 6.3.7 done; add 6.3.7a (ops: scheduler runner hardened)

### DIFF
--- a/docs/IRM.md
+++ b/docs/IRM.md
@@ -173,7 +173,14 @@ _Статуси_: **todo** — заплановано, **wip** — в робот
   - [ ] E2E: create/cancel order on demo env
   - [ ] Docs: README/CHANGELOG updated; tag v6.3.6
 
-- [ ] **6.3.7 — Документи: docs/HISTORY_AND_FILTERS.md, README, CHANGELOG**  `status: todo`
+- [x] **6.3.7 — Документи: docs/HISTORY_AND_FILTERS.md, README, CHANGELOG**  `status: done`
+
+- [x] **6.3.7a — Ops: Windows scheduler runner hardened (UTF-8, abs DB path, Set-Location; schtasks flags, full PowerShell path)**  `status: done`
+  - [ ] scripts/sqlite.maint.daily.ps1: Set-Location to repo root; absolute DB path; PYTHONIOENCODING=utf-8; direct .py
+  - [ ] scripts/schedule_sqlite_maint.ps1: full path to powershell.exe; correct flags for /SC DAILY
+  - [ ] README: add scheduler note (Start In not required; absolute DB path)
+  - [ ] CHANGELOG: add Unreleased ops entry
+  - [ ] Release: tag v6.3.7a
 
 - [ ] **6.3.8 — CI: покриття, бейдж**  `status: todo`
 

--- a/docs/irm.phase6.yaml
+++ b/docs/irm.phase6.yaml
@@ -1,5 +1,5 @@
 phase: '6.3'
-updated_at: '2025-09-14T15:01:31Z'
+updated_at: '2025-09-16T10:50:04Z'
 status_legend:
   todo: заплановано
   wip: в роботі
@@ -55,8 +55,17 @@ sections:
   - 'Docs: README/CHANGELOG updated; tag v6.3.6'
 - id: 6.3.7
   name: 'Документи: docs/HISTORY_AND_FILTERS.md, README, CHANGELOG'
-  status: todo
+  status: done
   tasks: []
+- id: 6.3.7a
+  name: "Ops: Windows scheduler runner hardened (UTF-8, abs DB path, Set-Location; schtasks flags, full PowerShell path)"
+  status: done
+  tasks:
+  - 'scripts/sqlite.maint.daily.ps1: Set-Location to repo root; absolute DB path; PYTHONIOENCODING=utf-8; direct .py'
+  - 'scripts/schedule_sqlite_maint.ps1: full path to powershell.exe; correct flags for /SC DAILY'
+  - 'README: add scheduler note (Start In not required; absolute DB path)'
+  - 'CHANGELOG: add Unreleased ops entry'
+  - 'Release: tag v6.3.7a'
 - id: 6.3.8
   name: 'CI: покриття, бейдж'
   status: todo


### PR DESCRIPTION
**What**
- Update `docs/irm.phase6.yaml`:
  - set **6.3.7 — Documentation update** to `status: done`,
  - add **6.3.7a — Ops: Windows scheduler runner hardened** as `status: done`.
- Re-generate `docs/IRM.md` via generator (no manual edits).

**Why**
- Reflects merged documentation work (6.3.7) and post-release ops patch **v6.3.7a** (scheduler runner fixes).
- Keeps IRM as the single source of truth, consistent with YAML & generator output.

**Details (6.3.7a content reference)**
- Runner (`scripts/sqlite.maint.daily.ps1`):
  - sets working directory (`Set-Location`) to repo root,
  - resolves **absolute** DB path (from `SQLITE_DB_PATH` or default `data\signals.db`),
  - forces UTF‑8 I/O (`PYTHONIOENCODING=utf-8`),
  - invokes CLI via direct `.py` (no `-m`).
- Scheduler registration (`scripts/schedule_sqlite_maint.ps1`):
  - uses full path to `powershell.exe` in `/TR`,
  - fixes flags for `/SC DAILY` (removed invalid `/D`, `/RI` for DAILY).
- Docs:
  - README — note that runner sets working directory and uses absolute DB path; **Start in** may remain N/A.
  - CHANGELOG — Unreleased ops note.
- Release: tag **v6.3.7a** and published GitHub release.

**How (generator)**
```powershell
# Generate + write IRM for phase 6.3 (no manual IRM.md edits)
python .\tools\irm_phase6_gen.py --write --phase 6.3

# Sanity check
python .\tools\irm_phase6_gen.py --check --phase 6.3
```

**Validation**
- `docs/IRM.md` shows:
  - `[x] 6.3.7 — ...  status: done`
  - `[x] 6.3.7a — Ops: Windows scheduler runner hardened ... status: done`
- Generator `--check` returns the expected diff or clean state after `--write`.
- (Operational) Scheduler job runs with `LastTaskResult = 0`; log ends with `SQLiteMaint DONE` (already verified).

**Scope**
- Docs only (YAML + generated markdown). No runtime changes.

**Risk**
- Low. The IRM is generated from YAML; no manual edits to `IRM.md`.
