### PR TITLE
ci(pre-commit): add IRM Phase 6 sync guard (no manual IRM.md edits)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,12 @@
     hooks:
       - id: isort
         stages: [manual]
+
+repos:
+  - repo: local
+    hooks:
+      - id: irm-phase6-check
+        name: IRM Phase 6 sync check
+        entry: python tools/irm_phase6_gen.py --check --phase 6.3
+        language: system
+        pass_filenames: false


### PR DESCRIPTION


**What**
Add a local pre-commit hook that runs the IRM generator check for Phase 6:
```bash
python tools/irm_phase6_gen.py --check --phase 6.3
```
This blocks commits when `docs/IRM.md` is out of sync with `docs/irm.phase6.yaml`,
enforcing generator-only updates (no manual edits of IRM.md).

**Why**
- Prevents accidental manual edits in `docs/IRM.md`.
- Keeps IRM as the single source of truth derived from YAML via the generator.

**Changes**
- `.pre-commit-config.yaml`: add `repo: local` hook
  - `id: irm-phase6-check`
  - `language: system`, `pass_filenames: false`
  - `entry: python tools/irm_phase6_gen.py --check --phase 6.3`

**How to validate locally**
```powershell
# ensure venv is active
pre-commit run -a

# simulate a drift (should FAIL the commit)
#   1) make a trivial manual change in docs/IRM.md
#   2) git commit -m "test"   # hook should block and show the diff
#   3) restore IRM.md (git restore -- docs/IRM.md) or re-generate:
python .\tools\irm_phase6_gen.py --write --phase 6.3
```

**Scope**
- Dev tooling only. No runtime/production changes.

**Risk**
- Low. Hook relies on existing Python tooling in the repo.
- If someone commits without pre-commit enabled, CI should still catch drift in a future step (can add similar check to CI later).

**Follow-ups (optional)**
- Add a CI job that runs the same check (fails the build on drift).
