### PR TITLE
ci(GitHub Actions): add IRM Phase 6 sync check

### DIFF
--- a/.github/workflows/irm-check.yml
+++ b/.github/workflows/irm-check.yml
@@ -1,0 +1,36 @@
+name: IRM Phase 6 Check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/IRM.md'
+      - 'docs/irm.phase6.yaml'
+      - 'tools/irm_phase6_gen.py'
+      - '.github/workflows/irm-check.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/IRM.md'
+      - 'docs/irm.phase6.yaml'
+      - 'tools/irm_phase6_gen.py'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps (best-effort)
+        run: |
+          if [ -f requirements.txt ]; then
+            python -m pip install -r requirements.txt || true
+          fi
+
+      - name: IRM 6.3 sync check
+        run: python tools/irm_phase6_gen.py --check --phase 6.3


### PR DESCRIPTION
Adds a CI job to run: python tools/irm_phase6_gen.py --check --phase 6.3
Blocks PRs/pushes when docs/IRM.md is out of sync with docs/irm.phase6.yaml.
