### PR TITLE
docs(IRM): add 6.3.7b (IRM guards: strict pre-commit + GH Actions)

### DIFF
--- a/docs/IRM.md
+++ b/docs/IRM.md
@@ -182,6 +182,11 @@ _Статуси_: **todo** — заплановано, **wip** — в робот
   - [ ] CHANGELOG: add Unreleased ops entry
   - [ ] Release: tag v6.3.7a
 
+- [x] **6.3.7b — CI/Pre-commit: IRM guards (strict local + GH Actions)**  `status: done`
+  - [ ] pre-commit: forbid manual IRM.md without YAML
+  - [ ] CI (GitHub Actions): irm-check.yml runs generator check on PR/push
+  - [ ] README: contributor note about IRM workflow
+
 - [ ] **6.3.8 — CI: покриття, бейдж**  `status: todo`
 
 - [ ] **6.3.9 — Генерувати секцію з YAML**  `status: todo`

--- a/docs/irm.phase6.yaml
+++ b/docs/irm.phase6.yaml
@@ -66,6 +66,13 @@ sections:
   - 'README: add scheduler note (Start In not required; absolute DB path)'
   - 'CHANGELOG: add Unreleased ops entry'
   - 'Release: tag v6.3.7a'
+- id: 6.3.7b
+  name: "CI/Pre-commit: IRM guards (strict local + GH Actions)"
+  status: done
+  tasks:
+  - "pre-commit: forbid manual IRM.md without YAML"
+  - "CI (GitHub Actions): irm-check.yml runs generator check on PR/push"
+  - "README: contributor note about IRM workflow"
 - id: 6.3.8
   name: 'CI: покриття, бейдж'
   status: todo


### PR DESCRIPTION
Records IRM guard work:
- strict local pre-commit (blocks IRM.md without YAML)
- GH Actions workflow irm-check.yml for generator sync on PR/push
- README contributor note (IRM workflow)

