### PR TITLE
docs: add IRM workflow note (Phase 6 generator, pre-commit guard, CI check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,26 @@ docs/
 
 ---
 
+### IRM workflow (Phase 6)
+
+> Не редагуйте `docs/IRM.md` вручну — файл генерується з YAML.
+
+Правильний процес:
+1. Зміни внесіть у `docs/irm.phase6.yaml`.
+2. Згенеруйте IRM для Phase 6:
+   ```powershell
+   python tools/irm_phase6_gen.py --write --phase 6.3
+   ```
+3. Закомітьте **разом**: `docs/irm.phase6.yaml` і `docs/IRM.md`.
+4. Локальний pre-commit guard заблокує коміт, якщо `IRM.md` без YAML.
+5. У CI (GitHub Actions) є додаткова перевірка синхронності.
+
+Швидка перевірка перед комітом:
+```powershell
+python tools/irm_phase6_gen.py --check --phase 6.3
+pre-commit run -a
+```
+
 ## Траблшутінг
 
 - **`pip install -r requirements.txt` падає через \x00** — не використовуйте `-Encoding Unicode` для `requirements.txt`; зберігайте файл у **UTF-8**.


### PR DESCRIPTION
# docs: add IRM workflow note (Phase 6 generator, pre-commit guard, CI check)

## Summary
Adds a short contributor note to **README.md** describing the correct workflow for editing **IRM**:
- Do **not** edit `docs/IRM.md` manually — it is generated.
- Make changes in `docs/irm.phase6.yaml`.
- Re-generate Phase 6 IRM via:
  ```powershell
  python tools/irm_phase6_gen.py --write --phase 6.3
  ```
- Commit **both** `docs/irm.phase6.yaml` and `docs/IRM.md` together.
- Local pre-commit guard and GitHub Actions workflow enforce the sync.

## Motivation
We previously had accidental manual edits to `docs/IRM.md`. This note makes the workflow explicit for contributors and reduces friction with the new guards.

## Changes
- README: adds section **“IRM workflow (Phase 6)”** with step-by-step guidance:
  - where to edit,
  - how to generate,
  - how to verify (pre-commit + CI).

## How to verify
1. Open README → find section **“IRM workflow (Phase 6)”**.
2. Follow steps:
   ```powershell
   python tools/irm_phase6_gen.py --check --phase 6.3
   pre-commit run -a
   ```
3. Confirm that a commit with `docs/IRM.md` alone is blocked by the strict guard, and that CI runs the generator check on PR/push.

## Scope / Impact
- Documentation only. No runtime changes.
- Compatible with existing pre-commit and CI setup.

## Checklist
- [x] README updated
- [x] Pre-commit guard active (local)
- [x] CI guard active (GH Actions)
- [x] No breaking changes
