### PR TITLE
CI: tests + local coverage badge (auto-update)  IRM 6.3.8 done

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install -U pip
-          pip install -r requirements.txt
+          if [ -f requirements.txt ]; then pip install -r requirements.txt || true; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt || true; fi
           pip install pre-commit
 
       # For PRs: compute changed files against the base branch
@@ -43,12 +44,12 @@ jobs:
           echo "Changed files: $CHANGED"
 
       # Run pre-commit only on changed files for PRs
-      - name: Pre-commit (pull_request — changed files only)
+      - name: Pre-commit (pull_request  changed files only)
         if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.none != 'true' }}
         run: pre-commit run --files ${{ steps.changes.outputs.files }}
 
       # For pushes (non-PR), keep full run
-      - name: Pre-commit (push — all files)
+      - name: Pre-commit (push  all files)
         if: ${{ github.event_name != 'pull_request' }}
         run: pre-commit run --all-files
 

--- a/.github/workflows/tests-coverage-badge.yml
+++ b/.github/workflows/tests-coverage-badge.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
   push:
     branches: ["main", "ci/**", "feat/**", "fix/**"]
+    paths-ignore:
+      - "docs/coverage.svg"
 
 jobs:
   tests:
+    # allow committing coverage.svg back to the repo
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,3 +54,12 @@ jobs:
           name: coverage-badge
           path: docs/coverage.svg
           if-no-files-found: error
+
+      # Commit updated badge back to the repo on pushes to main
+      - name: Commit updated coverage badge to repo (main only)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(coverage): update docs/coverage.svg [skip ci]"
+          file_pattern: docs/coverage.svg
+          branch: main

--- a/.github/workflows/tests-coverage-badge.yml
+++ b/.github/workflows/tests-coverage-badge.yml
@@ -1,0 +1,51 @@
+﻿name: Tests + Coverage Badge
+
+on:
+  pull_request:
+  push:
+    branches: ["main", "ci/**", "feat/**", "fix/**"]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt || true; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt || true; fi
+          pip install pytest pytest-cov coverage-badge
+
+      - name: Run pytest with coverage
+        shell: bash
+        run: |
+          pytest -q
+
+      - name: Generate local coverage badge
+        shell: bash
+        run: |
+          mkdir -p docs
+          python -m coverage_badge -o docs/coverage.svg -f
+
+      - name: Upload coverage.xml
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: error
+
+      - name: Upload coverage.svg
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-badge
+          path: docs/coverage.svg
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This project follows **QS v1.0** aligned with **Working Agreements v2.0**.
 
 [![Digest E2E Smoke](https://github.com/VadymTeterin/bybit-arb-bot/actions/workflows/digest-e2e-smoke.yml/badge.svg?branch=main)](https://github.com/VadymTeterin/bybit-arb-bot/actions/workflows/digest-e2e-smoke.yml)
 
+[![Coverage](docs/coverage.svg)](docs/coverage.svg)
+
 > Windows 11 · Python 3.11+ · aiogram 3 · Bybit REST & WebSocket v5 · pydantic-settings v2
 
 **Мета:** Telegram-бот, що в реальному часі аналізує базис між **Spot** та **USDT-перпетуалами** на Bybit, відбирає **топ-3** монети за порогом (за замовчуванням **1%**), застосовує фільтри ліквідності, зберігає історію та надсилає алерти у Telegram з троттлінгом.

--- a/docs/IRM.md
+++ b/docs/IRM.md
@@ -187,7 +187,11 @@ _Статуси_: **todo** — заплановано, **wip** — в робот
   - [ ] CI (GitHub Actions): irm-check.yml runs generator check on PR/push
   - [ ] README: contributor note about IRM workflow
 
-- [ ] **6.3.8 — CI: покриття, бейдж**  `status: todo`
+- [x] **6.3.8 — CI: покриття, бейдж**  `status: done`
+  - [ ] pytest-cov configured; coverage.xml generated
+  - [ ] CI workflow runs tests w/ coverage, uploads artifact
+  - [ ] Local coverage badge (docs/coverage.svg) generated in CI
+  - [ ] README badge added
 
 - [ ] **6.3.9 — Генерувати секцію з YAML**  `status: todo`
 

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">68%</text>
+        <text x="80" y="14">68%</text>
+    </g>
+</svg>

--- a/docs/irm.phase6.yaml
+++ b/docs/irm.phase6.yaml
@@ -1,5 +1,5 @@
 phase: '6.3'
-updated_at: '2025-09-16T10:50:04Z'
+updated_at: '2025-09-18T11:58:32Z'
 status_legend:
   todo: заплановано
   wip: в роботі
@@ -74,9 +74,13 @@ sections:
   - "CI (GitHub Actions): irm-check.yml runs generator check on PR/push"
   - "README: contributor note about IRM workflow"
 - id: 6.3.8
-  name: 'CI: покриття, бейдж'
-  status: todo
-  tasks: []
+  name: "CI: покриття, бейдж"
+  status: done
+  tasks:
+  - "pytest-cov configured; coverage.xml generated"
+  - "CI workflow runs tests w/ coverage, uploads artifact"
+  - "Local coverage badge (docs/coverage.svg) generated in CI"
+  - "README badge added"
 - id: 6.3.9
   name: Генерувати секцію з YAML
   status: todo

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,15 @@
+# pytest.ini
 [pytest]
+# Where to discover tests
 testpaths = tests
 python_files = test_*.py
-norecursedirs = .venv dev tmp build dist .git
+
+# Exclude noisy dirs
+norecursedirs = .venv dev tmp build dist .git .github
+
+# Coverage defaults:
+# - Measure src package (adjust if your top-level package differs)
+# - Generate coverage.xml for CI integrations
+# - Show missing lines in terminal
+# - Enforce minimal threshold to avoid regressions
+addopts = --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=67

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest==8.4.1
 pytest-cov==5.0.0
 coverage==7.6.1
 types-requests==2.32.0.20250301
+pyyaml==6.0.1


### PR DESCRIPTION
**Що зроблено (6.3.8):**
- pytest-cov + coverage.xml
- README: локальний coverage-бейдж (docs/coverage.svg)
- CI: тести + генерація coverage.svg + артефакти
- CI: авто-коміт coverage.svg на пушах у main (paths-ignore для уникнення циклів)
- IRM: 6.3.8 переведено в `done`

Після merge у `main` бейдж оновлюватиметься автоматично на кожному пуші.