### PR TITLE
ci: dispatch + badge author=bot

### DIFF
--- a/.github/workflows/tests-coverage-badge.yml
+++ b/.github/workflows/tests-coverage-badge.yml
@@ -1,6 +1,7 @@
 ﻿name: Tests + Coverage Badge
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: ["main", "ci/**", "feat/**", "fix/**"]
@@ -60,7 +61,11 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
+          commit_user_name: github-actions[bot]
+          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           commit_message: "chore(coverage): update docs/coverage.svg [skip ci]"
           file_pattern: docs/coverage.svg
           branch: main
+
 


### PR DESCRIPTION
Enable manual dispatch and force coverage badge auto-commits to be authored by github-actions[bot].