### PR TITLE
docs(changelog): 6.3.8  CI coverage badge & auto-commit(bots)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@
 
 `------------------------------------------------------------------------------------------------`
 
+## [6.3.8] — 2025-09-18
+**Phase 6 — Step-6.3.8 · CI: покриття, бейдж**
+
+### Added
+- **CI workflow** `tests-coverage-badge.yml`: запуск на `pull_request` і `push` до `main` (+ ручний `workflow_dispatch`).
+- **Покриття**: `pytest` + `pytest-cov` → `coverage.xml`; локальний бейдж `docs/coverage.svg` через `coverage-badge`.
+- **Артефакти**: збереження `coverage-xml` і `coverage-badge` у GitHub Actions.
+- **Авто-коміт бейджа на main** (`stefanzweifel/git-auto-commit-action@v5`) — автор і комітер **github-actions[bot]**;
+  повідомлення: `chore(coverage): update docs/coverage.svg [skip ci]`.
+- **README**: додано бейдж покриття у шапку.
+
+### Changed
+- `paths-ignore: ["docs/coverage.svg"]` щоб уникнути CI-циклів.
+- Додано швидкий тест `tests/test_infra_notify_import.py` для стабілізації порогу ≥67%.
+
+### Notes
+- IRM: секція **6.3.8** відмічена як `done`; далі — крок **6.3.9** (генерація IRM з YAML).
+
+
+`------------------------------------------------------------------------------------------------`
+
 ## [6.3.7b] - 2025-09-17
 ### Added
 - README: розділ “IRM workflow (Phase 6)” (правильний процес редагування IRM)
@@ -447,7 +468,6 @@
 - Старт проєкту: структура `src/`, `tests/`, конфіг і логування; вхідна точка `python -m src.main <command>`.
 
 `------------------------------------------------------------------------------------------------`
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,30 @@ Get-Content .\logs\sqlite_maint.log -Tail 100
 - Документи оновлено: README/CHANGELOG, тег **v6.3.6**.
 
 
+### Coverage badge (6.3.8)
+
+У репозиторії налаштовано workflow **Tests + Coverage Badge** (`.github/workflows/tests-coverage-badge.yml`), який:
+
+- запускається на **pull_request**, на **push** у `main`, `ci/**`, `feat/**`, `fix/**`, а також має **workflow_dispatch** (ручний запуск);
+- виконує `pytest` із збиранням покриття та генерує локальний бейдж **`docs/coverage.svg`**;
+- завантажує артефакти: `coverage-xml.zip` (із `coverage.xml`) і `coverage-badge.zip` (із `docs/coverage.svg`);
+- на **push у `main`** комітить оновлений бейдж назад у репозиторій за допомогою **stefanzweifel/git-auto-commit-action@v5** з параметрами:
+  - `commit_user_name: github-actions[bot]`
+  - `commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com`
+  - `commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`
+  - `commit_message: "chore(coverage): update docs/coverage.svg [skip ci]"`
+  - `branch: main`
+- щоб уникнути CI‑циклу, у тригерах додано `paths-ignore: docs/coverage.svg`.
+
+**Ручний запуск (на `main`):**
+```powershell
+gh workflow run tests-coverage-badge.yml --ref main
+# останній workflow_dispatch-ран:
+$rid = gh run list --workflow tests-coverage-badge.yml -e workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId'
+# переглянути параметри авто-коміту в логах:
+gh run view $rid --log | Select-String -Pattern 'git-auto-commit-action@v5|commit_user_name|commit_user_email|commit_author'
+```
+
 
 ## Вимоги
 


### PR DESCRIPTION
- CI: тести + покриття + локальний бейдж (coverage.svg)
- Артефакти: coverage.xml і coverage.svg
- Авто-коміт бейджа: author/committer = github-actions[bot]
- paths-ignore для docs/coverage.svg (щоб не зациклити CI)
- Додано workflow_dispatch для ручного запуску
- README: бейдж покриття