### PR TITLE
7.0.0.b: scaffold RiskManager module + minimal unit test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,7 @@ LIQUIDITY__MIN_PRICE=0.001             # exclude ultra-low-priced assets
 # TELEGRAM_CHAT_ID=          # == TG_CHAT_ID == TELEGRAM_ALERT_CHAT_ID
 # TG_CHAT_ID=
 # TELEGRAM_ALERT_CHAT_ID=
-# 
+#
 # BYBIT_IS_TESTNET=1
 # BYBIT_API_KEY=
 # BYBIT_API_SECRET=
@@ -137,3 +137,7 @@ SQLITE_MAINT_VACUUM_STRATEGY=incremental
 
 # Safety time cap for maintenance run (seconds)
 SQLITE_MAINT_MAX_DURATION_SEC=60
+
+RISK_DRY_RUN=true
+RISK_MAX_POS_USD=0
+RISK_MAX_EXPOSURE_PCT=0

--- a/src/core/risk_manager.py
+++ b/src/core/risk_manager.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class RiskConfig:
+    dry_run: bool
+    max_pos_usd: float
+    max_exposure_pct: float
+
+
+class RiskManager:
+    """Phase 7 scaffold (7.0.0): placeholder interface; logic arrives in 7.1.x."""
+
+    def __init__(self, cfg: RiskConfig) -> None:
+        self.cfg = cfg
+
+    def check(self) -> bool:
+        """Placeholder: always allow. Real checks will enforce limits in 7.1.x."""
+        return True

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,7 @@
+from src.core.risk_manager import RiskManager, RiskConfig
+
+
+def test_scaffold_instantiates_and_allows():
+    cfg = RiskConfig(dry_run=True, max_pos_usd=0.0, max_exposure_pct=0.0)
+    rm = RiskManager(cfg)
+    assert rm.check() is True


### PR DESCRIPTION
UA:
Підкрок 7.0.0.b (Phase 7 kickoff & scaffolding).
Додає каркас модулю ризик-менеджменту та мінімальний юніт-тест:

- src/core/risk_manager.py: RiskConfig, RiskManager (плейсхолдер інтерфейсу; логіка з лімітами прийде у 7.1.x).
- tests/test_risk_manager.py: smoke-тест інстанціювання та базової поведінки (check() -> True).

SSOT/YAML та IRM.view не змінювалися. Коміт не ставить галочку на 7.0.0 — це зробимо після завершення всіх підпунктів.

EN:
Sub-step 7.0.0.b (Phase 7 kickoff & scaffolding).
Adds a scaffold of the risk management module and a minimal unit test:

- src/core/risk_manager.py: RiskConfig, RiskManager (placeholder interface; real limits arrive in 7.1.x).
- tests/test_risk_manager.py: a smoke test for instantiation and baseline behavior (check() -> True).

SSOT/YAML and IRM.view were not changed. We don’t tick 7.0.0 yet — will do after all sub-items are completed.
